### PR TITLE
Add zuban type-check baseline and pre-commit hook to authentication service

### DIFF
--- a/backend-services/authentication/.pre-commit-config.yaml
+++ b/backend-services/authentication/.pre-commit-config.yaml
@@ -30,6 +30,11 @@ repos:
         entry: uv run ruff format
         types:
           - python
+      - id: zuban-check
+        name: zuban check
+        language: system
+        entry: uv run zuban check
+        pass_filenames: false
       - id: pytest
         name: pytest
         entry: uv run pytest

--- a/backend-services/authentication/pyproject.toml
+++ b/backend-services/authentication/pyproject.toml
@@ -26,7 +26,18 @@ dev = [
   "pytest-cov>=7",
   "pytest-mock>=3.15.1",
   "ruff>=0.15.8",
+  "zuban>=0.6.1",
 ]
+
+[tool.ruff]
+line-length = 88
+format.docstring-code-format = true
+lint.select = [ "ANN", "E", "F" ]
+lint.per-file-ignores."__init__.py" = [ "I" ]
+lint.pycodestyle.max-line-length = 120
 
 [tool.pytest]
 ini_options.testpaths = [ "tests" ]
+
+[tool.zuban]
+strict = false


### PR DESCRIPTION
### Motivation
- Introduce an incremental type-checking baseline for the `authentication` service so type checks can be adopted and tightened over time. 
- Align annotation and lint policies with other backend services that include the `ANN` Ruff rules to reduce drift between services. 
- Ensure type checks run as part of the local pre-commit workflow to catch issues early. 

### Description
- Add `zuban>=0.6.1` to the `dev` dependency group in `backend-services/authentication/pyproject.toml`. 
- Add a baseline `[tool.zuban]` config with `strict = false` in `pyproject.toml` to enable gradual adoption. 
- Introduce `[tool.ruff]` settings in `pyproject.toml` (`line-length = 88`, `lint.select = [ "ANN", "E", "F" ]`, per-file ignores and max-line-length) to align lint/annotation policies with other services. 
- Add a local `zuban-check` pre-commit hook in `backend-services/authentication/.pre-commit-config.yaml` that runs `uv run zuban check` with `pass_filenames: false`. 

### Testing
- Attempted to run `uv run --project backend-services/authentication ruff check backend-services/authentication`, but the command failed due to inability to reach PyPI for dependency resolution, so automated lint/type checks could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eade55bbc883308fd7d065de70f04a)