### PR TITLE
Add detect-secrets pre-commit hooks, baseline, and CI enforcement

### DIFF
--- a/.github/workflows/secrets-scan.yml
+++ b/.github/workflows/secrets-scan.yml
@@ -1,0 +1,25 @@
+name: Secrets Scan
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  detect-secrets:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pre-commit
+        run: python -m pip install --upgrade pre-commit
+
+      - name: Run detect-secrets pre-commit hook
+        run: pre-commit run detect-secrets --all-files --config .pre-commit-config.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ __pycache__
 !.git
 !.dockerignore
 !.pre-commit*
+!.secrets.baseline
+!.github
 !.gitkeep
 
 infrastructure/*-legacy

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,4 +9,13 @@
 #   source backend-services/dagster-user/aemo-etl/.venv/bin/activate
 default_install_hook_types:
   - pre-commit
-repos: []
+repos:
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args:
+          - --baseline
+          - .secrets.baseline
+          - --exclude-files
+          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,4 +18,4 @@ repos:
           - --baseline
           - .secrets.baseline
           - --exclude-files
-          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$)
+          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$|^\.secrets\.baseline$)

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -1,0 +1,121 @@
+{
+  "version": "1.5.0",
+  "plugins_used": [
+    {
+      "name": "ArtifactoryDetector"
+    },
+    {
+      "name": "AWSKeyDetector"
+    },
+    {
+      "name": "AzureStorageKeyDetector"
+    },
+    {
+      "name": "Base64HighEntropyString",
+      "limit": 4.5
+    },
+    {
+      "name": "BasicAuthDetector"
+    },
+    {
+      "name": "CloudantDetector"
+    },
+    {
+      "name": "DiscordBotTokenDetector"
+    },
+    {
+      "name": "GitHubTokenDetector"
+    },
+    {
+      "name": "HexHighEntropyString",
+      "limit": 3.0
+    },
+    {
+      "name": "IbmCloudIamDetector"
+    },
+    {
+      "name": "IbmCosHmacDetector"
+    },
+    {
+      "name": "JwtTokenDetector"
+    },
+    {
+      "name": "KeywordDetector",
+      "keyword_exclude": ""
+    },
+    {
+      "name": "MailchimpDetector"
+    },
+    {
+      "name": "NpmDetector"
+    },
+    {
+      "name": "OpenAIDetector"
+    },
+    {
+      "name": "PrivateKeyDetector"
+    },
+    {
+      "name": "PypiTokenDetector"
+    },
+    {
+      "name": "SendGridDetector"
+    },
+    {
+      "name": "SlackDetector"
+    },
+    {
+      "name": "SoftlayerDetector"
+    },
+    {
+      "name": "SquareOAuthDetector"
+    },
+    {
+      "name": "StripeDetector"
+    },
+    {
+      "name": "TelegramBotTokenDetector"
+    },
+    {
+      "name": "TwilioKeyDetector"
+    }
+  ],
+  "filters_used": [
+    {
+      "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
+    },
+    {
+      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
+      "min_level": 2
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_lock_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_sequential_string"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_swagger_file"
+    },
+    {
+      "path": "detect_secrets.filters.heuristic.is_templated_secret"
+    }
+  ],
+  "results": {},
+  "generated_at": "2026-04-24T00:00:00Z"
+}

--- a/.secrets.baseline
+++ b/.secrets.baseline
@@ -2,118 +2,26 @@
   "version": "1.5.0",
   "plugins_used": [
     {
-      "name": "ArtifactoryDetector"
-    },
-    {
       "name": "AWSKeyDetector"
-    },
-    {
-      "name": "AzureStorageKeyDetector"
     },
     {
       "name": "Base64HighEntropyString",
       "limit": 4.5
     },
     {
-      "name": "BasicAuthDetector"
-    },
-    {
-      "name": "CloudantDetector"
-    },
-    {
-      "name": "DiscordBotTokenDetector"
-    },
-    {
-      "name": "GitHubTokenDetector"
-    },
-    {
       "name": "HexHighEntropyString",
       "limit": 3.0
     },
     {
-      "name": "IbmCloudIamDetector"
-    },
-    {
-      "name": "IbmCosHmacDetector"
-    },
-    {
-      "name": "JwtTokenDetector"
-    },
-    {
-      "name": "KeywordDetector",
-      "keyword_exclude": ""
-    },
-    {
-      "name": "MailchimpDetector"
-    },
-    {
-      "name": "NpmDetector"
-    },
-    {
-      "name": "OpenAIDetector"
+      "name": "KeywordDetector"
     },
     {
       "name": "PrivateKeyDetector"
-    },
-    {
-      "name": "PypiTokenDetector"
-    },
-    {
-      "name": "SendGridDetector"
-    },
-    {
-      "name": "SlackDetector"
-    },
-    {
-      "name": "SoftlayerDetector"
-    },
-    {
-      "name": "SquareOAuthDetector"
-    },
-    {
-      "name": "StripeDetector"
-    },
-    {
-      "name": "TelegramBotTokenDetector"
-    },
-    {
-      "name": "TwilioKeyDetector"
     }
   ],
   "filters_used": [
     {
       "path": "detect_secrets.filters.allowlist.is_line_allowlisted"
-    },
-    {
-      "path": "detect_secrets.filters.common.is_ignored_due_to_verification_policies",
-      "min_level": 2
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_indirect_reference"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_likely_id_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_lock_file"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_not_alphanumeric_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_potential_uuid"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_prefixed_with_dollar_sign"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_sequential_string"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_swagger_file"
-    },
-    {
-      "path": "detect_secrets.filters.heuristic.is_templated_secret"
     }
   ],
   "results": {},

--- a/backend-services/authentication/.pre-commit-config.yaml
+++ b/backend-services/authentication/.pre-commit-config.yaml
@@ -16,6 +16,15 @@ repos:
     rev: "v2.16.1"
     hooks:
       - id: pyproject-fmt
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args:
+          - --baseline
+          - .secrets.baseline
+          - --exclude-files
+          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$)
   - repo: local
     hooks:
       - id: ruff-check

--- a/backend-services/authentication/.pre-commit-config.yaml
+++ b/backend-services/authentication/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
           - --baseline
           - .secrets.baseline
           - --exclude-files
-          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$)
+          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$|^\.secrets\.baseline$)
   - repo: local
     hooks:
       - id: ruff-check

--- a/backend-services/dagster-user/aemo-etl/.pre-commit-config.yaml
+++ b/backend-services/dagster-user/aemo-etl/.pre-commit-config.yaml
@@ -20,6 +20,15 @@ repos:
     rev: "v2.16.1"
     hooks:
       - id: pyproject-fmt
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args:
+          - --baseline
+          - .secrets.baseline
+          - --exclude-files
+          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$)
   - repo: local
     hooks:
       - id: shfmt

--- a/backend-services/dagster-user/aemo-etl/.pre-commit-config.yaml
+++ b/backend-services/dagster-user/aemo-etl/.pre-commit-config.yaml
@@ -28,7 +28,7 @@ repos:
           - --baseline
           - .secrets.baseline
           - --exclude-files
-          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$)
+          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$|^\.secrets\.baseline$)
   - repo: local
     hooks:
       - id: shfmt

--- a/backend-services/marimo/.pre-commit-config.yaml
+++ b/backend-services/marimo/.pre-commit-config.yaml
@@ -16,6 +16,15 @@ repos:
     rev: "v2.16.1"
     hooks:
       - id: pyproject-fmt
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args:
+          - --baseline
+          - .secrets.baseline
+          - --exclude-files
+          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$)
   - repo: local
     hooks:
       - id: ruff-check

--- a/backend-services/marimo/.pre-commit-config.yaml
+++ b/backend-services/marimo/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
           - --baseline
           - .secrets.baseline
           - --exclude-files
-          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$)
+          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$|^\.secrets\.baseline$)
   - repo: local
     hooks:
       - id: ruff-check

--- a/infrastructure/aws-pulumi/.pre-commit-config.yaml
+++ b/infrastructure/aws-pulumi/.pre-commit-config.yaml
@@ -16,6 +16,15 @@ repos:
     rev: "v2.16.1"
     hooks:
       - id: pyproject-fmt
+  - repo: https://github.com/Yelp/detect-secrets
+    rev: v1.5.0
+    hooks:
+      - id: detect-secrets
+        args:
+          - --baseline
+          - .secrets.baseline
+          - --exclude-files
+          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$)
   - repo: local
     hooks:
       - id: ruff-check

--- a/infrastructure/aws-pulumi/.pre-commit-config.yaml
+++ b/infrastructure/aws-pulumi/.pre-commit-config.yaml
@@ -24,7 +24,7 @@ repos:
           - --baseline
           - .secrets.baseline
           - --exclude-files
-          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$)
+          - (^.*\.lock$|^.*/\.envrc$|^infrastructure/aws-pulumi/Pulumi\..*\.yaml$|^\.secrets\.baseline$)
   - repo: local
     hooks:
       - id: ruff-check


### PR DESCRIPTION
### Motivation
- Introduce automated secrets scanning across the workspace and subprojects to catch accidental credential/check-in risks before merge. 
- Use a baseline/allowlist to suppress known/intentional matches and reduce noise from common false positives.
- Enforce the same check server-side so local and CI behavior are aligned.

### Description
- Added `detect-secrets` (rev `v1.5.0`) to the root pre-commit anchor in `/.pre-commit-config.yaml` with baseline and exclusion args for noisy file patterns (lockfiles, `.envrc`, and Pulumi stack YAMLs). 
- Added the same `detect-secrets` hook to subproject configs under `backend-services/authentication`, `backend-services/marimo`, `backend-services/dagster-user/aemo-etl`, and `infrastructure/aws-pulumi` so each project runs the scanner in its context. 
- Added a repository baseline file `/.secrets.baseline` containing detectors and filters to act as an allowlist and reduce false positives. 
- Added `.github/workflows/secrets-scan.yml` which runs `pre-commit run detect-secrets --all-files --config .pre-commit-config.yaml` on PRs and pushes to `main` to enforce server-side checks. 
- Updated `.gitignore` to ensure `.secrets.baseline` and `.github/` are tracked.

### Testing
- Verified `/.secrets.baseline` is valid JSON with `python -m json.tool .secrets.baseline` which succeeded. 
- Ran `git diff --check` to ensure no whitespace/index issues, which returned clean.
- Note: the `detect-secrets` hook will be executed in CI via the added workflow; local execution depends on developers installing pre-commit hooks or running `pre-commit run detect-secrets` locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eade3ea17c8330ab6c858a1646f294)