### PR TITLE
Add Marimo + Dagster multi-tenant per-user EC2 strategy spec

### DIFF
--- a/specs/marimo-multi-tenant-strategy.md
+++ b/specs/marimo-multi-tenant-strategy.md
@@ -1,0 +1,258 @@
+# Marimo + Dagster multi-tenant analytics strategy (per-user EC2)
+
+## Table of contents
+- [1) Context and goal](#1-context-and-goal)
+- [2) Current Pulumi baseline (what already exists)](#2-current-pulumi-baseline-what-already-exists)
+- [3) Target architecture for per-user marimo services](#3-target-architecture-for-per-user-marimo-services)
+- [4) Spec backlog broken into subtasks](#4-spec-backlog-broken-into-subtasks)
+- [5) Detailed spec cards (work one at a time)](#5-detailed-spec-cards-work-one-at-a-time)
+- [6) Suggested implementation order](#6-suggested-implementation-order)
+- [7) Risks and open decisions](#7-risks-and-open-decisions)
+
+## 1) Context and goal
+
+You want a user-by-user analytics environment where each authenticated user can:
+
+- sign in and launch their own marimo service
+- query curated data from the Dagster ecosystem
+- use Polars + plotting libraries interactively
+- operate in isolated compute/network boundaries
+
+This document expands the initial strategy into an actionable specification backlog so we can execute one spec at a time.
+
+## 2) Current Pulumi baseline (what already exists)
+
+From the current `infrastructure/aws-pulumi` stack:
+
+1. **Network foundation exists**
+   - Single VPC, public + private subnets, custom NAT instance routing.
+2. **Security groups exist for current services**
+   - Bastion, Dagster webserver/user-code/daemon, Postgres, Caddy, FastAPI auth.
+3. **Existing auth edge exists**
+   - FastAPI auth EC2 service (private subnet), Caddy EC2 reverse proxy (public subnet), Cognito-related env config.
+4. **Dagster runtime exists on ECS Fargate**
+   - User code, daemon, webserver admin/guest with service discovery.
+5. **Core data infra exists**
+   - S3 buckets + DynamoDB lock table + Postgres.
+
+### Implication for this project
+
+We should **extend** this architecture (not replace it):
+
+- keep Dagster on ECS and treat it as orchestration/control plane for data production
+- add a new per-user marimo service plane that reads governed outputs
+- reuse existing auth/caddy patterns where useful, but introduce explicit per-user session brokering
+
+## 3) Target architecture for per-user marimo services
+
+### Control plane (shared)
+
+- **Identity provider**: existing Cognito integration remains source of user identity.
+- **Session broker API** (new): maps authenticated user → assigned marimo instance and issues short-lived access token.
+- **Provisioner worker** (new): start/stop/create/terminate per-user EC2 instances and persistent volumes.
+- **State store** (new): user→instance mapping, lifecycle state, policy tier, last-activity timestamps.
+
+### Data plane (per user)
+
+- Dedicated EC2 instance per user (or per active user cohort).
+- marimo service bound to localhost behind local reverse proxy.
+- Python runtime includes `polars`, plotting libs, and internal data access SDK.
+- Instance profile IAM with tenant-scoped least privilege.
+- Optional per-user persistent EBS for workspace state.
+
+### Data access pattern
+
+- marimo code consumes data through an internal SDK/API surface.
+- SDK uses short-lived credentials and enforces tenant/user context.
+- Fine-grained data policy must be enforced at query/data platform layer (not notebook-only).
+
+## 4) Spec backlog broken into subtasks
+
+> Status key: `todo`, `in-progress`, `blocked`, `done`.
+
+| Spec ID | Subtask | Outcome | Dependencies | Status |
+|---|---|---|---|---|
+| S0 | Baseline architecture alignment | Confirm how new marimo plane integrates with existing Pulumi modules and routing | none | todo |
+| S1 | Identity + session broker | Authenticated user gets signed marimo session and deterministic routing | S0 | todo |
+| S2 | Per-user compute lifecycle | Provision/start/stop/terminate per-user EC2 reliably | S0, S1 | todo |
+| S3 | Marimo runtime image & bootstrap | Standardized marimo + polars runtime with hardening and observability | S2 | todo |
+| S4 | Networking and ingress model | Private compute + controlled ingress from authenticated edge only | S0, S1, S2 | todo |
+| S5 | Data access SDK + IAM policy model | Controlled access to Dagster outputs and data stores with tenant scope | S1, S3 | todo |
+| S6 | Workspace persistence and backup | Durable per-user notebooks/artifacts with restore process | S2, S3 | todo |
+| S7 | Idle shutdown, cost controls, quotas | Predictable spend and auto-lifecycle management | S2, S6 | todo |
+| S8 | Observability, audit, SLOs | End-to-end traceability and operational readiness | S1-S7 | todo |
+| S9 | Security hardening + threat model | Baseline controls documented and validated | S1-S8 | todo |
+
+## 5) Detailed spec cards (work one at a time)
+
+## S0 — Baseline architecture alignment
+
+**Goal**
+Define where to add new Pulumi components (`marimo_broker`, `marimo_instances`, `marimo_security_groups`, etc.) without destabilizing existing Dagster components.
+
+**Deliverables**
+- Architecture decision record (ADR) for integration points.
+- Pulumi module map showing existing vs new component ownership.
+- Naming/tagging conventions for marimo resources.
+
+**Acceptance criteria**
+- Clear boundary documented: Dagster orchestration vs user analytics plane.
+- No required breaking changes to existing ECS Dagster services.
+
+## S1 — Identity + session broker
+
+**Goal**
+After Cognito login, user receives short-lived broker token and lands on their own marimo service.
+
+**Deliverables**
+- Broker API contract (`/session/start`, `/session/status`, `/session/stop`).
+- Token schema (claims: `sub`, `tenant`, `instance_id`, `exp`).
+- AuthN/AuthZ checks between edge proxy, broker, and marimo instance.
+
+**Acceptance criteria**
+- User cannot access another user instance even with URL guessing.
+- Session token expires quickly and is rotated/reissued safely.
+
+## S2 — Per-user compute lifecycle
+
+**Goal**
+Automate creation and lifecycle of one EC2 workspace per user.
+
+**Deliverables**
+- Provisioning workflow (create instance + attach volume + register route).
+- Resume workflow (start/hibernate wake + health check gate).
+- Termination workflow (snapshot/archive + cleanup).
+
+**Acceptance criteria**
+- p95 warm resume under agreed threshold.
+- Deterministic idempotent provisioning for repeated requests.
+
+## S3 — Marimo runtime image & bootstrap
+
+**Goal**
+Create repeatable runtime with marimo, polars, plotting libs, and security defaults.
+
+**Deliverables**
+- Golden AMI or bootstrapped instance profile for runtime install.
+- Standard library bundle (`polars`, `pyarrow`, plotting package choices).
+- Startup service definition (systemd/container) with health endpoint.
+
+**Acceptance criteria**
+- Same runtime versions across users in same release.
+- No unauthenticated public marimo endpoint exposure.
+
+## S4 — Networking and ingress model
+
+**Goal**
+Ensure user instances are private and only reachable through authenticated routing.
+
+**Deliverables**
+- New SG rules for broker/edge-to-marimo traffic.
+- Private subnet placement and route strategy.
+- DNS/routing strategy for user-specific endpoints.
+
+**Acceptance criteria**
+- No direct internet ingress to marimo instances.
+- All ingress requests are identity-bound and auditable.
+
+## S5 — Data access SDK + IAM policy model
+
+**Goal**
+Provide a safe API in marimo notebooks for querying approved datasets.
+
+**Deliverables**
+- Internal SDK package and allowed API surface.
+- IAM policy templates scoped by tenant/user prefix.
+- Data policy mapping (row/column/asset-level where applicable).
+
+**Acceptance criteria**
+- Access denied for out-of-scope datasets.
+- SDK emits structured audit events on reads.
+
+## S6 — Workspace persistence and backup
+
+**Goal**
+Persist notebooks/artifacts while keeping compute disposable.
+
+**Deliverables**
+- User workspace filesystem layout and retention policy.
+- Backup pipeline (EBS snapshots and/or S3 sync).
+- Restore workflow for replacement instance.
+
+**Acceptance criteria**
+- User data survives stop/start and controlled replacement.
+- Recovery runbook validated in non-prod.
+
+## S7 — Idle shutdown, cost controls, quotas
+
+**Goal**
+Keep per-user EC2 model financially manageable.
+
+**Deliverables**
+- Idle detection and stop policy.
+- Per-user size tier and budget guardrails.
+- Cost attribution tags and dashboard dimensions.
+
+**Acceptance criteria**
+- Instances auto-stop after policy idle threshold.
+- Monthly cost report available by user/team.
+
+## S8 — Observability, audit, SLOs
+
+**Goal**
+Make service operable with clear reliability targets.
+
+**Deliverables**
+- Metrics: login-to-ready, broker latency, start failure rate, marimo health.
+- Logs: auth decisions, provisioning actions, SDK data reads.
+- Alerting + runbooks for top failure modes.
+
+**Acceptance criteria**
+- SLO dashboard exists and alerts are actionable.
+- Incident triage can reconstruct user session path.
+
+## S9 — Security hardening + threat model
+
+**Goal**
+Formalize baseline controls and validate them before broader rollout.
+
+**Deliverables**
+- Threat model (identity spoofing, lateral access, data exfiltration scenarios).
+- Hardening checklist (IMDSv2, EBS encryption, SSM-only admin, no static keys).
+- Security test plan (auth bypass, tenant breakout, secret leakage).
+
+**Acceptance criteria**
+- Critical/high findings resolved or risk-accepted explicitly.
+- Security sign-off before production onboarding.
+
+## 6) Suggested implementation order
+
+Recommended order for iterative delivery:
+
+1. **S0** architecture alignment
+2. **S1** identity/session broker contract
+3. **S2** lifecycle automation
+4. **S3** runtime standardization
+5. **S4** network controls
+6. **S5** data access SDK
+7. **S6** persistence/backup
+8. **S7** cost controls
+9. **S8** observability
+10. **S9** security hardening sign-off
+
+This sequence gets a secure MVP quickly, then layers governance and operational maturity.
+
+## 7) Risks and open decisions
+
+Open decisions to resolve early:
+
+- Should user instances be long-lived (persistent) or mostly ephemeral with fast restore?
+- Should routing remain Caddy-centric or move to ALB + OIDC for broker integration?
+- What is the minimum approved plotting stack (e.g., Plotly/Altair/Matplotlib) for marimo?
+- Is one instance per user required always, or can low-risk users share pooled compute tiers?
+
+Known risks:
+
+- Per-user EC2 can become expensive without strict idle controls.
+- Identity/routing misconfiguration is a high-impact security risk.
+- Data policy gaps in backend systems cannot be fixed purely in notebook code.

--- a/specs/marimo-multi-tenant-strategy.md
+++ b/specs/marimo-multi-tenant-strategy.md
@@ -5,6 +5,7 @@
 - [2) Current Pulumi baseline (what already exists)](#2-current-pulumi-baseline-what-already-exists)
 - [3) Target architecture for per-user marimo services](#3-target-architecture-for-per-user-marimo-services)
 - [4) Spec backlog broken into subtasks](#4-spec-backlog-broken-into-subtasks)
+- [Spec implementation folders](#spec-implementation-folders)
 - [5) Detailed spec cards (work one at a time)](#5-detailed-spec-cards-work-one-at-a-time)
 - [6) Suggested implementation order](#6-suggested-implementation-order)
 - [7) Risks and open decisions](#7-risks-and-open-decisions)
@@ -82,6 +83,22 @@ We should **extend** this architecture (not replace it):
 | S7 | Idle shutdown, cost controls, quotas | Predictable spend and auto-lifecycle management | S2, S6 | todo |
 | S8 | Observability, audit, SLOs | End-to-end traceability and operational readiness | S1-S7 | todo |
 | S9 | Security hardening + threat model | Baseline controls documented and validated | S1-S8 | todo |
+
+
+## Spec implementation folders
+
+Each subtask now has a dedicated implementation plan file in `specs/marimo-multi-tenant-strategy/`:
+
+- [S0 baseline architecture alignment](./marimo-multi-tenant-strategy/S0-baseline-architecture-alignment.md)
+- [S1 identity and session broker](./marimo-multi-tenant-strategy/S1-identity-and-session-broker.md)
+- [S2 per-user compute lifecycle](./marimo-multi-tenant-strategy/S2-per-user-compute-lifecycle.md)
+- [S3 marimo runtime image and bootstrap](./marimo-multi-tenant-strategy/S3-marimo-runtime-image-and-bootstrap.md)
+- [S4 networking and ingress model](./marimo-multi-tenant-strategy/S4-networking-and-ingress-model.md)
+- [S5 data access SDK and IAM policy model](./marimo-multi-tenant-strategy/S5-data-access-sdk-and-iam-policy-model.md)
+- [S6 workspace persistence and backup](./marimo-multi-tenant-strategy/S6-workspace-persistence-and-backup.md)
+- [S7 idle shutdown, cost controls, and quotas](./marimo-multi-tenant-strategy/S7-idle-shutdown-cost-controls-and-quotas.md)
+- [S8 observability, audit, and SLOs](./marimo-multi-tenant-strategy/S8-observability-audit-and-slos.md)
+- [S9 security hardening and threat model](./marimo-multi-tenant-strategy/S9-security-hardening-and-threat-model.md)
 
 ## 5) Detailed spec cards (work one at a time)
 

--- a/specs/marimo-multi-tenant-strategy/S0-baseline-architecture-alignment.md
+++ b/specs/marimo-multi-tenant-strategy/S0-baseline-architecture-alignment.md
@@ -8,23 +8,174 @@ Define exactly how the new Marimo plane fits into the existing Pulumi architectu
 - Propose new component boundaries for Marimo-specific resources.
 - Establish naming/tagging conventions for cost attribution and ownership.
 
-## Proposed implementation
-1. Create a `marimo/` component namespace in Pulumi for:
-   - `MarimoBrokerComponentResource`
-   - `MarimoWorkspaceComponentResource`
-   - `MarimoWorkspaceSecurityGroupsComponentResource`
-2. Keep existing Dagster ECS services unchanged; expose curated data through a dedicated SDK/API path.
-3. Add a resource dependency graph diagram and ADR documenting why Marimo remains a separate plane.
+## Component model (what each component does)
 
-## Pulumi changes
-- Add placeholder component files and exports only (no runtime deployment in S0).
-- Add stack config keys for Marimo naming and default region assumptions.
+## Existing components we keep as-is
+
+### 1) `VpcComponentResource` (existing)
+- Owns VPC, public/private subnet baseline, and routing primitives.
+- Marimo plane reuses this VPC and private subnet model.
+
+### 2) `SecurityGroupsComponentResource` (existing)
+- Owns SGs for Dagster webserver/user-code/daemon, Postgres, bastion, Caddy, FastAPI auth.
+- Marimo adds a **separate SG component** to avoid coupling with current Dagster SG lifecycle.
+
+### 3) `EcsClusterComponentResource` + Dagster ECS services (existing)
+- Runs Dagster control plane and pipelines.
+- No direct code/runtime changes in S0; Marimo is an adjacent analytics plane.
+
+### 4) `FastAPIAuthComponentResource` + `CaddyServerComponentResource` (existing)
+- Current auth edge and reverse-proxy path.
+- In S0, these remain stable; we only define how broker/session integration will attach later.
+
+### 5) Postgres / S3 / DynamoDB components (existing)
+- Continue serving existing system responsibilities.
+- S0 only defines where Marimo metadata should live (not yet provisioned).
+
+## New components introduced by Marimo plane
+
+### A) `MarimoBrokerComponentResource` (new)
+**Purpose**: control-plane API that maps authenticated users to workspace lifecycle and routing state.
+
+**Responsibilities**
+- Validate incoming authenticated identity assertions.
+- Resolve `user_id -> workspace_id` mapping.
+- Trigger lifecycle actions (`start`, `stop`, `status`) via provisioner service.
+- Mint short-lived workspace access tokens.
+
+**Does not do**
+- Run user code.
+- Query large datasets directly.
+
+### B) `MarimoProvisionerComponentResource` (new)
+**Purpose**: orchestrate EC2 workspace lifecycle.
+
+**Responsibilities**
+- Create/start/stop/terminate per-user EC2 instances.
+- Attach encrypted EBS workspace volumes.
+- Register readiness and health state back to metadata store.
+
+**Does not do**
+- Handle user HTTP traffic.
+- Handle auth UX.
+
+### C) `MarimoWorkspaceComponentResource` (new)
+**Purpose**: define launch template/runtime identity for user workspace instances.
+
+**Responsibilities**
+- Launch template, AMI pinning, instance profile/IAM, tags.
+- Bootstrapping marimo runtime + internal SDK.
+- Emit health telemetry and activity heartbeats.
+
+### D) `MarimoWorkspaceSecurityGroupsComponentResource` (new)
+**Purpose**: isolate workspace network boundaries.
+
+**Responsibilities**
+- Permit ingress only from trusted edge/broker SG(s).
+- Permit explicit egress required for data access + telemetry.
+- Block workspace-to-workspace lateral connectivity by default.
+
+### E) `MarimoMetadataStoreComponentResource` (new)
+**Purpose**: persistence for workspace mapping and state.
+
+**Candidate storage options**
+- DynamoDB table (`user_id` partition key, `workspace_id` sort key) for lifecycle and routing state.
+- Optional Postgres schema if relational reporting is preferred.
+
+**Stores**
+- Workspace lifecycle (`provisioning`, `running`, `stopped`, `error`).
+- Routing target + last health check timestamp.
+- Policy tier and quota metadata.
+
+## Interaction flow (high-level)
+
+1. User authenticates with existing auth stack (Cognito/FastAPI auth path).
+2. Edge calls broker with authenticated identity context.
+3. Broker checks metadata store for user workspace state.
+4. If needed, broker asks provisioner to start/provision workspace.
+5. Provisioner updates workspace state until healthy.
+6. Broker returns signed session + route target.
+7. Edge routes user traffic only to assigned workspace.
+
+## Interfaces defined in S0 (for S1/S2 to implement)
+
+### Broker API surface (contract placeholder)
+- `POST /session/start`
+- `GET /session/status`
+- `POST /session/stop`
+
+### Provisioner API surface (internal)
+- `POST /workspaces/{workspace_id}/start`
+- `POST /workspaces/{workspace_id}/stop`
+- `POST /workspaces/{workspace_id}/provision`
+- `GET /workspaces/{workspace_id}/health`
+
+### Metadata schema (minimum)
+- `workspace_id`
+- `user_id`
+- `tenant_id`
+- `state`
+- `instance_id`
+- `private_ip`
+- `last_heartbeat_at`
+- `policy_tier`
+
+## Pulumi implementation boundaries
+
+## New module layout (proposed)
+- `infrastructure/aws-pulumi/components/marimo_broker.py`
+- `infrastructure/aws-pulumi/components/marimo_provisioner.py`
+- `infrastructure/aws-pulumi/components/marimo_workspace.py`
+- `infrastructure/aws-pulumi/components/marimo_workspace_security_groups.py`
+- `infrastructure/aws-pulumi/components/marimo_metadata_store.py`
+
+## `__main__.py` placement (proposed order)
+After existing VPC/security/auth foundations are created:
+1. `marimo_metadata_store`
+2. `marimo_workspace_security_groups`
+3. `marimo_broker`
+4. `marimo_provisioner`
+5. `marimo_workspace` (template/shared defs, not one resource per user in Pulumi)
+
+> Note: per-user instance creation should be runtime-driven by broker/provisioner, not statically declared as one Pulumi resource per user.
+
+## Naming/tagging conventions
+
+### Resource naming
+- Prefix: `${ENVIRONMENT}-energy-market-marimo-*`
+- Examples:
+  - `${NAME}-marimo-broker`
+  - `${NAME}-marimo-provisioner`
+  - `${NAME}-marimo-workspace-lt`
+
+### Required tags
+- `service=marimo`
+- `component=<broker|provisioner|workspace|metadata>`
+- `environment=<dev|staging|prod>`
+- `owner=<team>`
+- `tenant=<tenant_id>` (runtime resources)
+- `user_id=<user_id>` (workspace EC2/EBS runtime resources)
+- `cost_center=<finops key>`
+
+## Failure domains and ownership
+
+- **Broker down**: no new session starts, but running workspaces can continue serving existing sessions.
+- **Provisioner down**: no lifecycle transitions; broker returns retryable status.
+- **Metadata store degraded**: routing/state uncertainty; broker must fail closed.
+- **Workspace unhealthy**: broker/provisioner can recycle or replace instance.
+
+Ownership split:
+- Platform team: broker, provisioner, metadata store, Pulumi modules.
+- Data platform: SDK/data policy definitions.
+- Security: IAM baseline and auth/token standards.
 
 ## Deliverables
-- ADR markdown under `specs/`.
-- Pulumi module map diagram.
-- Standard tag schema: `owner`, `user_id`, `tenant`, `service`, `environment`, `cost_center`.
+- ADR markdown under `specs/` describing component boundaries.
+- Pulumi module map diagram (existing vs marimo-new).
+- Sequence diagram from auth -> broker -> provisioner -> workspace route.
+- Tagging and naming policy documented.
 
 ## Acceptance criteria
 - Integration points are documented and approved.
-- No changes to existing Dagster service behavior.
+- No changes to existing Dagster service behavior in this phase.
+- A clear handoff contract exists for S1 (broker/session) and S2 (lifecycle automation).

--- a/specs/marimo-multi-tenant-strategy/S0-baseline-architecture-alignment.md
+++ b/specs/marimo-multi-tenant-strategy/S0-baseline-architecture-alignment.md
@@ -1,0 +1,30 @@
+# S0 — Baseline architecture alignment
+
+## Objective
+Define exactly how the new Marimo plane fits into the existing Pulumi architecture without breaking current Dagster services.
+
+## Scope
+- Inventory current components: VPC, security groups, ECS cluster/services, Caddy, FastAPI auth, Postgres, S3, DynamoDB.
+- Propose new component boundaries for Marimo-specific resources.
+- Establish naming/tagging conventions for cost attribution and ownership.
+
+## Proposed implementation
+1. Create a `marimo/` component namespace in Pulumi for:
+   - `MarimoBrokerComponentResource`
+   - `MarimoWorkspaceComponentResource`
+   - `MarimoWorkspaceSecurityGroupsComponentResource`
+2. Keep existing Dagster ECS services unchanged; expose curated data through a dedicated SDK/API path.
+3. Add a resource dependency graph diagram and ADR documenting why Marimo remains a separate plane.
+
+## Pulumi changes
+- Add placeholder component files and exports only (no runtime deployment in S0).
+- Add stack config keys for Marimo naming and default region assumptions.
+
+## Deliverables
+- ADR markdown under `specs/`.
+- Pulumi module map diagram.
+- Standard tag schema: `owner`, `user_id`, `tenant`, `service`, `environment`, `cost_center`.
+
+## Acceptance criteria
+- Integration points are documented and approved.
+- No changes to existing Dagster service behavior.

--- a/specs/marimo-multi-tenant-strategy/S1-identity-and-session-broker.md
+++ b/specs/marimo-multi-tenant-strategy/S1-identity-and-session-broker.md
@@ -1,0 +1,37 @@
+# S1 — Identity and session broker
+
+## Objective
+Issue short-lived, user-bound sessions that route each authenticated user to their own Marimo workspace.
+
+## Scope
+- Broker API design
+- Token/session model
+- Edge integration path from current auth stack
+
+## Proposed implementation
+1. Build a broker service (FastAPI) in private subnet/ECS service.
+2. Add endpoints:
+   - `POST /session/start`
+   - `GET /session/status`
+   - `POST /session/stop`
+3. On successful Cognito-authenticated identity, map `sub -> workspace_id`.
+4. Mint short-lived JWT (5–15 min) with claims: `sub`, `tenant`, `workspace_id`, `roles`, `exp`, `jti`.
+5. Caddy/ALB forwards only requests with valid broker-issued token to workspace.
+
+## Data model
+- `users` table: user metadata and tenant mapping.
+- `workspaces` table: workspace lifecycle + instance metadata.
+- `sessions` table: current/expired session records for audit.
+
+## Pulumi changes
+- New broker compute resource (start as EC2 or ECS Fargate).
+- Secret/config wiring for token-signing key and issuer metadata.
+
+## Deliverables
+- OpenAPI spec for broker.
+- Sequence diagram for login-to-workspace handoff.
+- Token validation middleware contract for edge.
+
+## Acceptance criteria
+- User cannot access another user's workspace by URL manipulation.
+- Expired/revoked token access denied at edge.

--- a/specs/marimo-multi-tenant-strategy/S2-per-user-compute-lifecycle.md
+++ b/specs/marimo-multi-tenant-strategy/S2-per-user-compute-lifecycle.md
@@ -1,0 +1,38 @@
+# S2 — Per-user compute lifecycle
+
+## Objective
+Automate creation, start, stop, and termination of one Marimo workspace instance per user.
+
+## Scope
+- Provisioning orchestration
+- Health checks
+- Idempotency and retry behavior
+
+## Proposed implementation
+1. Provisioning path:
+   - Create EC2 from hardened AMI
+   - Attach encrypted EBS volume
+   - Attach workspace IAM instance profile
+   - Register workspace state in DB
+2. Start/resume path:
+   - Start stopped instance
+   - Poll SSM or health endpoint until ready
+3. Stop/hibernate path:
+   - Idle timeout trigger from broker activity
+   - Persist state and stop safely
+4. Termination path:
+   - Snapshot/backup volume
+   - Delete instance, detach/cleanup networking
+
+## Pulumi + runtime changes
+- Pulumi defines launch template, IAM profile, SGs, subnet placement.
+- Runtime worker executes lifecycle via AWS SDK with idempotency keys.
+
+## Deliverables
+- State machine diagram.
+- Failure policy matrix (timeouts, retries, dead-letter handling).
+- Runbook for orphaned resources.
+
+## Acceptance criteria
+- Repeated start/provision requests are safe and deterministic.
+- p95 warm resume and cold provision metrics published.

--- a/specs/marimo-multi-tenant-strategy/S3-marimo-runtime-image-and-bootstrap.md
+++ b/specs/marimo-multi-tenant-strategy/S3-marimo-runtime-image-and-bootstrap.md
@@ -1,0 +1,34 @@
+# S3 — Marimo runtime image and bootstrap
+
+## Objective
+Standardize the per-user runtime with marimo, polars, plotting stack, and security defaults.
+
+## Scope
+- Runtime packaging
+- Startup service
+- Patch/version strategy
+
+## Proposed implementation
+1. Build a hardened base image/AMI containing:
+   - Python + marimo
+   - polars/pyarrow
+   - approved plotting libraries (plotly + altair or matplotlib)
+2. Bootstrap script installs only pinned dependencies.
+3. Run marimo via systemd or container with:
+   - localhost binding only
+   - health endpoint
+   - resource limits and log shipping
+4. Add version manifest for reproducibility and rollback.
+
+## Pulumi changes
+- Add AMI id/version config in stack settings.
+- Add user-data template version hash for controlled rollouts.
+
+## Deliverables
+- Runtime bill of materials (BOM).
+- Base image build pipeline spec.
+- Startup/health script and validation checklist.
+
+## Acceptance criteria
+- Workspace runtime versions are consistent per release channel.
+- marimo process is never directly internet-exposed.

--- a/specs/marimo-multi-tenant-strategy/S4-networking-and-ingress-model.md
+++ b/specs/marimo-multi-tenant-strategy/S4-networking-and-ingress-model.md
@@ -1,0 +1,33 @@
+# S4 — Networking and ingress model
+
+## Objective
+Enforce private-only workspace networking and authenticated ingress.
+
+## Scope
+- Security group model
+- Routing design
+- Private subnet + egress model
+
+## Proposed implementation
+1. Place workspace instances in private subnets only.
+2. Create dedicated SGs:
+   - `marimo-workspace-sg` (ingress only from edge/broker)
+   - `marimo-broker-sg`
+3. Restrict inbound ports to one app port from trusted SG only.
+4. Route strategy:
+   - Preferred: ALB + OIDC/JWT auth + broker-aware routing
+   - Transitional: Caddy validates broker token and forwards to workspace private IP
+5. Add VPC endpoints where possible to reduce open egress dependencies.
+
+## Pulumi changes
+- Add SG resources and SG-to-SG rules.
+- Add target-group/routing resources if ALB path selected.
+
+## Deliverables
+- Network diagram with trust boundaries.
+- Ingress/egress policy table.
+- Threat checks for lateral movement.
+
+## Acceptance criteria
+- No direct public ingress path to workspace instances.
+- All workspace requests are identity-scoped and logged.

--- a/specs/marimo-multi-tenant-strategy/S5-data-access-sdk-and-iam-policy-model.md
+++ b/specs/marimo-multi-tenant-strategy/S5-data-access-sdk-and-iam-policy-model.md
@@ -1,0 +1,32 @@
+# S5 — Data access SDK and IAM policy model
+
+## Objective
+Provide a safe interface for Marimo notebooks to access approved data with tenant-scoped permissions.
+
+## Scope
+- SDK API design
+- IAM scoping
+- Data policy mapping
+
+## Proposed implementation
+1. Create internal Python SDK with typed methods:
+   - `get_asset(name, partition=...)`
+   - `query_dataset(dataset_id, filters=...)`
+2. SDK injects user/tenant context from broker token claims.
+3. Map workspace role -> IAM policy templates:
+   - S3 prefix constraints
+   - Lake Formation/Snowflake/Databricks role constraints
+4. Emit structured audit events for every read/query action.
+
+## Pulumi changes
+- Add IAM policy documents and instance-profile attachments per workspace tier.
+- Add config references for data platform role mappings.
+
+## Deliverables
+- SDK package skeleton + API contract.
+- IAM policy library.
+- Audit event schema.
+
+## Acceptance criteria
+- Out-of-scope dataset requests are denied.
+- Data access events are attributable to individual users.

--- a/specs/marimo-multi-tenant-strategy/S6-workspace-persistence-and-backup.md
+++ b/specs/marimo-multi-tenant-strategy/S6-workspace-persistence-and-backup.md
@@ -1,0 +1,31 @@
+# S6 — Workspace persistence and backup
+
+## Objective
+Keep user work durable while treating compute as disposable.
+
+## Scope
+- Workspace filesystem conventions
+- Backup/restore workflows
+- Retention policies
+
+## Proposed implementation
+1. Standard layout:
+   - `/workspace/<user_id>/apps`
+   - `/workspace/<user_id>/data`
+   - `/workspace/<user_id>/.cache`
+2. Persist via encrypted EBS volume attached to workspace.
+3. Scheduled snapshots and/or incremental sync to S3.
+4. Restore flow creates replacement instance and reattaches/restores volume snapshot.
+
+## Pulumi changes
+- Define EBS encryption defaults and tagging.
+- Define backup scheduling resources (or document external scheduler integration).
+
+## Deliverables
+- Backup policy document (RPO/RTO targets).
+- Restore runbook with step-by-step commands.
+- Data retention and deletion policy.
+
+## Acceptance criteria
+- User notebooks survive stop/start and instance replacement.
+- Restore drill succeeds in non-prod within target RTO.

--- a/specs/marimo-multi-tenant-strategy/S7-idle-shutdown-cost-controls-and-quotas.md
+++ b/specs/marimo-multi-tenant-strategy/S7-idle-shutdown-cost-controls-and-quotas.md
@@ -1,0 +1,31 @@
+# S7 — Idle shutdown, cost controls, and quotas
+
+## Objective
+Control per-user EC2 spend with automated lifecycle rules and clear quota policies.
+
+## Scope
+- Idle detection
+- Instance sizing tiers
+- Cost visibility and controls
+
+## Proposed implementation
+1. Track activity heartbeat from broker/workspace.
+2. Apply policy thresholds:
+   - stop after N idle minutes
+   - hibernate where supported
+3. Define user tiers (small/medium/large) and approval flow for upgrades.
+4. Apply mandatory cost tags and publish daily cost report by user/team.
+5. Add safeguards (max concurrent instances, budget alarms).
+
+## Pulumi changes
+- Budget/alarm resources.
+- Tag policy enforcement and optional SCP/guardrail integration docs.
+
+## Deliverables
+- Idle policy matrix by user tier.
+- FinOps dashboard spec.
+- Escalation workflow for quota exceptions.
+
+## Acceptance criteria
+- Idle instances stop automatically and reliably.
+- Cost can be sliced by user and tenant.

--- a/specs/marimo-multi-tenant-strategy/S8-observability-audit-and-slos.md
+++ b/specs/marimo-multi-tenant-strategy/S8-observability-audit-and-slos.md
@@ -1,0 +1,36 @@
+# S8 — Observability, audit, and SLOs
+
+## Objective
+Make the platform operable with actionable telemetry and reliable incident triage.
+
+## Scope
+- Metrics, logs, traces
+- SLO definitions
+- Alerting and runbooks
+
+## Proposed implementation
+1. Metrics:
+   - login-to-ready latency
+   - broker API latency/error rate
+   - provision success/failure rate
+   - workspace health and utilization
+2. Logs:
+   - auth decisions
+   - provisioning actions
+   - SDK read/query events
+3. Tracing:
+   - correlate request from login -> broker -> workspace -> data access
+4. Alerts for SLO burn and critical failures.
+
+## Pulumi changes
+- CloudWatch log groups, metric filters, alarms, dashboards.
+- Optional integration with external observability platforms.
+
+## Deliverables
+- SLO definitions and alert thresholds.
+- Dashboard layouts.
+- Incident runbooks (top 5 failure modes).
+
+## Acceptance criteria
+- On-call can identify user-impacting failure within minutes.
+- Session-level audit trail is reconstructible end-to-end.

--- a/specs/marimo-multi-tenant-strategy/S9-security-hardening-and-threat-model.md
+++ b/specs/marimo-multi-tenant-strategy/S9-security-hardening-and-threat-model.md
@@ -1,0 +1,39 @@
+# S9 — Security hardening and threat model
+
+## Objective
+Finalize a production-ready baseline with explicit threat mitigations and verification.
+
+## Scope
+- Threat model
+- Hardening checklist
+- Security validation plan
+
+## Proposed implementation
+1. Threat model workshops covering:
+   - token theft/replay
+   - tenant breakout
+   - workspace-to-workspace lateral access
+   - data exfiltration patterns
+2. Hardening baseline:
+   - IMDSv2 only
+   - encrypted volumes and snapshots
+   - SSM-only administration (no public SSH)
+   - no static long-lived cloud keys
+   - restricted egress where feasible
+3. Validation:
+   - auth bypass tests
+   - policy enforcement tests
+   - secret handling checks
+
+## Pulumi changes
+- Enforce secure defaults in launch templates, IAM, and SGs.
+- Add compliance-oriented tags and audit hooks.
+
+## Deliverables
+- Threat model document.
+- Security checklist with ownership.
+- Go-live security sign-off template.
+
+## Acceptance criteria
+- Critical/high findings resolved or explicitly risk-accepted.
+- Security review completed before production rollout.


### PR DESCRIPTION
### Motivation

- Introduce a concrete strategy and execution backlog for providing per-user Marimo analytics environments that integrate with the existing Dagster control plane and Pulumi baseline.  
- Document required control-plane components (session broker, provisioner, state store) and per-user data-plane expectations (EC2 workspaces, IAM scoping, SDK access patterns).  
- Surface operational, security, and cost risks and open decisions to guide incremental implementation.

### Description

- Add a new specification document at `specs/marimo-multi-tenant-strategy.md` describing context, current Pulumi baseline, target architecture, and a prioritized spec backlog (`S0`–`S9`).  
- Define control-plane components (`session broker`, `provisioner worker`, `state store`) and per-user data-plane requirements (dedicated EC2, local proxy, IAM instance profiles, optional EBS).  
- Provide detailed spec cards for each backlog item (`S0`–`S9`), acceptance criteria, suggested implementation order, and a list of risks and unresolved decisions.  
- Keep Dagster on ECS as the orchestration/control plane and specify reuse of existing auth/Caddy patterns while adding per-user session brokering.

### Testing

- This change is documentation-only and did not include code changes that require automated tests.  
- No automated tests were added or executed for this spec file.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ecce9a0a1c833091cbe4b400a56a7e)