### PR TITLE
Restrict Caddy SSH ingress to bastion host

### DIFF
--- a/infrastructure/aws-pulumi/components/security_groups.py
+++ b/infrastructure/aws-pulumi/components/security_groups.py
@@ -199,19 +199,14 @@ class SecurityGroupsComponentResource(pulumi.ComponentResource):
 
     def _setup_caddy_instance(self) -> None:
         sg = self.register.caddy_instance
-        # SSH from admin IPs
-        for idx, ip in enumerate(ADMINISTRATOR_IPS):
-            aws.ec2.SecurityGroupRule(
-                f"{self.name}-caddy-ssh-{idx}",
-                type="ingress",
-                security_group_id=sg.id,
-                from_port=22,
-                to_port=22,
-                protocol="tcp",
-                cidr_blocks=[f"{ip}/32"],
-                description=f"SSH from admin {ip}",
-                opts=pulumi.ResourceOptions(parent=sg),
-            )
+        # SSH from bastion host only
+        self._tcp_ingress_from_sg(
+            f"{self.name}-caddy-ssh",
+            sg,
+            self.register.bastion_host,
+            22,
+            "SSH from bastion host",
+        )
         # HTTP + HTTPS from anywhere (ACME challenge + user traffic)
         for port, label in [(80, "http"), (443, "https")]:
             self._tcp_ingress_from_cidr(

--- a/infrastructure/aws-pulumi/docs/connectivity.md
+++ b/infrastructure/aws-pulumi/docs/connectivity.md
@@ -109,6 +109,7 @@ flowchart LR
 ## Traffic rules
 
 - Caddy is the only internet-facing service security group.
+- Caddy accepts SSH (port `22`) only from the bastion host.
 - FastAPI auth is private and only accepts traffic from Caddy plus SSH from the
   bastion host.
 - Dagster webservers accept port `3000` from Caddy and the bastion host.


### PR DESCRIPTION
### Motivation
- Harden network access by preventing direct SSH to the internet-facing Caddy instance from admin IPs and requiring operator SSH to hop via the bastion host.

### Description
- Replace CIDR-based SSH ingress rules on the Caddy security group with a single security-group-to-security-group ingress rule allowing port `22` only from the bastion host security group in `infrastructure/aws-pulumi/components/security_groups.py`.
- Update `infrastructure/aws-pulumi/docs/connectivity.md` to document that Caddy accepts SSH (port `22`) only from the bastion host.
- Change scope is limited to SSH ingress for Caddy and does not alter HTTP/HTTPS or other service connectivity.

### Testing
- Ran unit tests for security groups with `cd infrastructure/aws-pulumi && uv run pytest tests/unit/test_security_groups.py`, which completed successfully (`8 passed`).
- Ran repository hooks with `prek run --files infrastructure/aws-pulumi/components/security_groups.py`, which exercised lint/format hooks but failed due to an unrelated existing unit test (`tests/unit/test_dagster_core_config.py`) asserting a different `max_resume_run_attempts` value; the failure is not caused by these SG changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09a3f0e0883308ae1aee0bb7ee2a6)