### PR TITLE
Implement #25: Introduce shared S3 pending-object planning through the unzipper sensor

### DIFF
--- a/backend-services/dagster-user/aemo-etl/README.md
+++ b/backend-services/dagster-user/aemo-etl/README.md
@@ -274,6 +274,8 @@ aemo-etl/
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/defs/raw/nemweb_public_files.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/df_from_s3_keys/assets.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/df_from_s3_keys/definitions.py`
+  - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/s3_pending_objects.py`
+  - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/unzipper/sensors.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/defs/resources.py`
   - `backend-services/dagster-user/aemo-etl/Makefile`
   - `backend-services/dagster-user/aemo-etl/.pre-commit-config.yaml`

--- a/backend-services/dagster-user/aemo-etl/docs/architecture/high_level_architecture.md
+++ b/backend-services/dagster-user/aemo-etl/docs/architecture/high_level_architecture.md
@@ -247,6 +247,8 @@ flowchart TD
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/defs/resources.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/df_from_s3_keys/assets.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/df_from_s3_keys/definitions.py`
+  - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/s3_pending_objects.py`
+  - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/unzipper/sensors.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/defs/raw/table_metadata.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/defs/gas_model/silver_gas_dim_date.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/defs/gas_model/silver_gas_fact_operational_meter_flow.py`

--- a/backend-services/dagster-user/aemo-etl/docs/architecture/ingestion_flows.md
+++ b/backend-services/dagster-user/aemo-etl/docs/architecture/ingestion_flows.md
@@ -155,10 +155,12 @@ When `AWS_ENDPOINT_URL` points at LocalStack, the same flow runs against local S
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/definitions.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/df_from_s3_keys/assets.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/df_from_s3_keys/definitions.py`
+  - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/s3_pending_objects.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/maintenance/delta_tables.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/defs/resources.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/defs/gas_model/silver_gas_fact_operational_meter_flow.py`
   - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/unzipper/definitions.py`
+  - `backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/unzipper/sensors.py`
 - `sync.scope`: `behavior`
 - `sync.qa`:
   - `git diff --name-only`

--- a/backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/s3_pending_objects.py
+++ b/backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/s3_pending_objects.py
@@ -1,0 +1,155 @@
+from collections.abc import Mapping, Sequence
+from typing import cast
+
+from dagster import (
+    AssetKey,
+    DagsterRun,
+    DagsterRunStatus,
+    RunRequest,
+    SensorEvaluationContext,
+)
+
+from aemo_etl.utils import (
+    S3ObjectHead,
+    get_s3_object_keys_from_prefix_and_name_glob,
+)
+
+ACTIVE_RUN_STATUSES = (
+    DagsterRunStatus.QUEUED,
+    DagsterRunStatus.NOT_STARTED,
+    DagsterRunStatus.STARTING,
+    DagsterRunStatus.STARTED,
+)
+
+
+def is_asset_running(runs: Sequence[DagsterRun], asset_key: AssetKey) -> bool:
+    for run in runs:
+        if run.asset_selection and asset_key in run.asset_selection:
+            return True
+    return False
+
+
+def has_asset_failed(runs: Sequence[DagsterRun], asset_key: AssetKey) -> bool:
+    """Return True if the most recent completed run containing this asset failed."""
+    for run in runs:
+        if run.asset_selection and asset_key in run.asset_selection:
+            return run.status == DagsterRunStatus.FAILURE
+    return False
+
+
+def get_asset_glob_pattern(
+    context: SensorEvaluationContext,
+    *,
+    sensor_name: str,
+    asset_key: AssetKey,
+) -> str:
+    assert hasattr(context.repository_def, "assets_defs_by_key")
+
+    asset_defs = context.repository_def.assets_defs_by_key.get(asset_key)
+    assert hasattr(asset_defs, "metadata_by_key")
+    asset_meta = cast(
+        Mapping[str, object] | None,
+        asset_defs.metadata_by_key.get(asset_key),
+    )
+    assert asset_meta is not None and "glob_pattern" in asset_meta, (
+        f"{sensor_name} sensor unable to process {asset_key}: missing 'glob_pattern' metadata"
+    )
+    glob_pattern = asset_meta["glob_pattern"]
+    assert isinstance(glob_pattern, str), (
+        f"{sensor_name} sensor unable to process {asset_key}: 'glob_pattern' metadata must be a string"
+    )
+    return glob_pattern
+
+
+def select_s3_pending_object_keys(
+    *,
+    s3_source_prefix: str,
+    s3_file_glob: str,
+    object_head_mapping: Mapping[str, S3ObjectHead],
+    bytes_cap: float,
+    files_cap: int | None,
+) -> list[str]:
+    s3_object_keys = get_s3_object_keys_from_prefix_and_name_glob(
+        s3_prefix=s3_source_prefix,
+        s3_file_glob=s3_file_glob,
+        original_keys=list(object_head_mapping.keys()),
+    )
+    current_bytes = 0
+    objects_to_process: list[str] = []
+
+    for s3_object_key in s3_object_keys:
+        object_head = object_head_mapping[s3_object_key]
+        size_in_bytes = object_head["Size"]
+        if current_bytes + size_in_bytes > bytes_cap:
+            break
+        if files_cap is not None and len(objects_to_process) >= files_cap:
+            break
+        objects_to_process.append(s3_object_key)
+        current_bytes += size_in_bytes
+
+    return objects_to_process
+
+
+def build_s3_keys_run_config(
+    *,
+    asset_key: AssetKey,
+    s3_keys: Sequence[str],
+) -> dict[str, object]:
+    return {
+        "ops": {
+            asset_key.to_python_identifier(): {
+                "config": {
+                    "s3_keys": list(s3_keys),
+                },
+            },
+        },
+    }
+
+
+def build_s3_pending_objects_run_request(
+    *,
+    asset_key: AssetKey,
+    s3_keys: Sequence[str],
+) -> RunRequest | None:
+    if not s3_keys:
+        return None
+    return RunRequest(
+        asset_selection=[asset_key],
+        run_config=build_s3_keys_run_config(asset_key=asset_key, s3_keys=s3_keys),
+    )
+
+
+def plan_s3_pending_objects_run_request(
+    context: SensorEvaluationContext,
+    *,
+    sensor_name: str,
+    asset_key: AssetKey,
+    active_runs: Sequence[DagsterRun],
+    completed_runs: Sequence[DagsterRun],
+    s3_source_prefix: str,
+    object_head_mapping: Mapping[str, S3ObjectHead],
+    bytes_cap: float,
+    files_cap: int | None,
+) -> RunRequest | None:
+    s3_file_glob = get_asset_glob_pattern(
+        context,
+        sensor_name=sensor_name,
+        asset_key=asset_key,
+    )
+
+    if is_asset_running(active_runs, asset_key) or has_asset_failed(
+        completed_runs, asset_key
+    ):
+        return None
+
+    objects_to_process = select_s3_pending_object_keys(
+        s3_source_prefix=s3_source_prefix,
+        s3_file_glob=s3_file_glob,
+        object_head_mapping=object_head_mapping,
+        bytes_cap=bytes_cap,
+        files_cap=files_cap,
+    )
+    return build_s3_pending_objects_run_request(
+        asset_key=asset_key,
+        s3_keys=objects_to_process,
+    )

--- a/backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/unzipper/sensors.py
+++ b/backend-services/dagster-user/aemo-etl/src/aemo_etl/factories/unzipper/sensors.py
@@ -1,12 +1,7 @@
-from typing import Sequence, cast
-
 from dagster import (
-    AssetKey,
     AssetSelection,
-    DagsterRun,
     DagsterRunStatus,
     DefaultSensorStatus,
-    RunRequest,
     RunsFilter,
     SensorDefinition,
     SensorEvaluationContext,
@@ -15,33 +10,14 @@ from dagster import (
 )
 from dagster_aws.s3 import S3Resource
 
+from aemo_etl.factories.s3_pending_objects import (
+    ACTIVE_RUN_STATUSES,
+    plan_s3_pending_objects_run_request,
+)
 from aemo_etl.utils import (
     get_object_head_from_pages,
-    get_s3_object_keys_from_prefix_and_name_glob,
     get_s3_pagination,
 )
-
-ACTIVE_STATUSES = [
-    DagsterRunStatus.QUEUED,
-    DagsterRunStatus.NOT_STARTED,
-    DagsterRunStatus.STARTING,
-    DagsterRunStatus.STARTED,
-]
-
-
-def _is_running(runs: Sequence[DagsterRun], asset_key: AssetKey) -> bool:
-    for run in runs:
-        if run.asset_selection and asset_key in run.asset_selection:
-            return True
-    return False
-
-
-def _has_asset_failed(runs: Sequence[DagsterRun], asset_key: AssetKey) -> bool:
-    """Return True if the most recent completed run containing this asset failed."""
-    for run in runs:
-        if run.asset_selection and asset_key in run.asset_selection:
-            return run.status == DagsterRunStatus.FAILURE
-    return False
 
 
 def unzipper_sensor(
@@ -96,7 +72,7 @@ def unzipper_sensor(
         )
 
         active_runs = context.instance.get_runs(
-            filters=RunsFilter(statuses=list(ACTIVE_STATUSES))
+            filters=RunsFilter(statuses=list(ACTIVE_RUN_STATUSES))
         )
         completed_runs = context.instance.get_runs(
             filters=RunsFilter(
@@ -107,49 +83,18 @@ def unzipper_sensor(
         object_head_mapping = get_object_head_from_pages(pages, logger=context.log)
 
         for asset_key in asset_keys:
-            asset_defs = context.repository_def.assets_defs_by_key.get(asset_key)
-            assert hasattr(asset_defs, "metadata_by_key")
-            asset_meta = cast(dict[str, str], asset_defs.metadata_by_key.get(asset_key))
-            assert "glob_pattern" in asset_meta, (
-                f"{name} sensor unable to process {asset_key}: missing 'glob_pattern' metadata"
+            run_request = plan_s3_pending_objects_run_request(
+                context,
+                sensor_name=name,
+                asset_key=asset_key,
+                active_runs=active_runs,
+                completed_runs=completed_runs,
+                s3_source_prefix=s3_source_prefix,
+                object_head_mapping=object_head_mapping,
+                bytes_cap=bytes_cap,
+                files_cap=files_cap,
             )
-            s3_file_glob = asset_meta["glob_pattern"]
-
-            if _is_running(active_runs, asset_key) or _has_asset_failed(
-                completed_runs, asset_key
-            ):
-                continue
-
-            s3_object_keys = get_s3_object_keys_from_prefix_and_name_glob(
-                s3_prefix=s3_source_prefix,
-                s3_file_glob=s3_file_glob,
-                original_keys=cast(list[str], object_head_mapping.keys()),
-            )
-            current_bytes = 0
-            objects_to_process: list[str] = []
-
-            for s3_object_key in s3_object_keys:
-                object_head = object_head_mapping[s3_object_key]
-                size_in_bytes = object_head["Size"]
-                if current_bytes + size_in_bytes > bytes_cap:
-                    break
-                if files_cap is not None and len(objects_to_process) >= files_cap:
-                    break
-                objects_to_process.append(s3_object_key)
-                current_bytes += size_in_bytes
-
-            if objects_to_process:
-                yield RunRequest(
-                    asset_selection=[asset_key],
-                    run_config={
-                        "ops": {
-                            asset_key.to_python_identifier(): {
-                                "config": {
-                                    "s3_keys": objects_to_process,
-                                },
-                            }
-                        }
-                    },
-                )
+            if run_request is not None:
+                yield run_request
 
     return sensor_

--- a/backend-services/dagster-user/aemo-etl/tests/component/test_factories_unzipper.py
+++ b/backend-services/dagster-user/aemo-etl/tests/component/test_factories_unzipper.py
@@ -17,11 +17,7 @@ from aemo_etl.factories.unzipper.assets import (
 )
 from aemo_etl.factories.unzipper.definitions import unzipper_definitions_factory
 from aemo_etl.factories.unzipper.file_unzipper import S3FileUnzipper
-from aemo_etl.factories.unzipper.sensors import (
-    _has_asset_failed,
-    _is_running,
-    unzipper_sensor,
-)
+from aemo_etl.factories.unzipper.sensors import unzipper_sensor
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -57,51 +53,6 @@ _DIR_ZIP = _create_zip({"subdir/": b""})
 
 class _NoSuchKey(Exception):
     """Stand-in for s3_client.exceptions.NoSuchKey."""
-
-
-# ===========================================================================
-# sensors: _is_running / _has_asset_failed
-# ===========================================================================
-
-
-def test_is_running_found() -> None:
-    assert _is_running([_make_run(DagsterRunStatus.STARTED)], _ASSET_KEY) is True
-
-
-def test_is_running_not_found() -> None:
-    assert _is_running([], _ASSET_KEY) is False
-
-
-def test_is_running_no_selection() -> None:
-    run = MagicMock()
-    run.asset_selection = None
-    assert _is_running([run], _ASSET_KEY) is False
-
-
-def test_has_asset_failed_true() -> None:
-    assert _has_asset_failed([_make_run(DagsterRunStatus.FAILURE)], _ASSET_KEY) is True
-
-
-def test_has_asset_failed_false_success() -> None:
-    assert _has_asset_failed([_make_run(DagsterRunStatus.SUCCESS)], _ASSET_KEY) is False
-
-
-def test_has_asset_failed_no_match() -> None:
-    other = AssetKey(["bronze", "other"])
-    assert (
-        _has_asset_failed([_make_run(DagsterRunStatus.FAILURE, other)], _ASSET_KEY)
-        is False
-    )
-
-
-def test_has_asset_failed_empty() -> None:
-    assert _has_asset_failed([], _ASSET_KEY) is False
-
-
-def test_has_asset_failed_no_selection() -> None:
-    run = MagicMock()
-    run.asset_selection = None
-    assert _has_asset_failed([run], _ASSET_KEY) is False
 
 
 # ===========================================================================
@@ -157,7 +108,7 @@ def test_unzipper_sensor_inner(
         return_value={_ZIP_KEY: {"Size": 100}},
     )
     mocker.patch(
-        "aemo_etl.factories.unzipper.sensors.get_s3_object_keys_from_prefix_and_name_glob",
+        "aemo_etl.factories.s3_pending_objects.get_s3_object_keys_from_prefix_and_name_glob",
         return_value=[_ZIP_KEY] if has_requests or not active_runs else [],
     )
     mocker.patch.object(AssetSelection, "resolve", return_value=frozenset([_ASSET_KEY]))
@@ -191,7 +142,7 @@ def test_unzipper_sensor_bytes_cap(mocker: MockerFixture) -> None:
         return_value=big_heads,
     )
     mocker.patch(
-        "aemo_etl.factories.unzipper.sensors.get_s3_object_keys_from_prefix_and_name_glob",
+        "aemo_etl.factories.s3_pending_objects.get_s3_object_keys_from_prefix_and_name_glob",
         return_value=many_keys,
     )
     mocker.patch.object(AssetSelection, "resolve", return_value=frozenset([_ASSET_KEY]))
@@ -231,7 +182,7 @@ def test_unzipper_sensor_files_cap(mocker: MockerFixture) -> None:
         return_value=small_heads,
     )
     mocker.patch(
-        "aemo_etl.factories.unzipper.sensors.get_s3_object_keys_from_prefix_and_name_glob",
+        "aemo_etl.factories.s3_pending_objects.get_s3_object_keys_from_prefix_and_name_glob",
         return_value=many_keys,
     )
     mocker.patch.object(AssetSelection, "resolve", return_value=frozenset([_ASSET_KEY]))
@@ -268,7 +219,7 @@ def test_unzipper_sensor_no_keys(mocker: MockerFixture) -> None:
         return_value={},
     )
     mocker.patch(
-        "aemo_etl.factories.unzipper.sensors.get_s3_object_keys_from_prefix_and_name_glob",
+        "aemo_etl.factories.s3_pending_objects.get_s3_object_keys_from_prefix_and_name_glob",
         return_value=[],
     )
     mocker.patch.object(AssetSelection, "resolve", return_value=frozenset([_ASSET_KEY]))

--- a/backend-services/dagster-user/aemo-etl/tests/unit/test_factories_s3_pending_objects.py
+++ b/backend-services/dagster-user/aemo-etl/tests/unit/test_factories_s3_pending_objects.py
@@ -1,0 +1,245 @@
+from unittest.mock import MagicMock, patch
+
+import pytest
+from dagster import AssetKey, DagsterRunStatus, RunRequest
+
+from aemo_etl.factories.s3_pending_objects import (
+    build_s3_pending_objects_run_request,
+    build_s3_keys_run_config,
+    get_asset_glob_pattern,
+    has_asset_failed,
+    is_asset_running,
+    plan_s3_pending_objects_run_request,
+    select_s3_pending_object_keys,
+)
+from aemo_etl.utils import S3ObjectHead
+
+_ASSET_KEY = AssetKey(["bronze", "vicgas", "unzipper_vicgas"])
+_ZIP_KEY = "bronze/vicgas/data.zip"
+
+
+def _make_run(
+    status: DagsterRunStatus,
+    asset_key: AssetKey | None = _ASSET_KEY,
+) -> MagicMock:
+    run = MagicMock()
+    run.asset_selection = {asset_key} if asset_key is not None else None
+    run.status = status
+    return run
+
+
+def _build_context(glob_pattern: str | None = "*.zip") -> MagicMock:
+    context = MagicMock()
+    mock_asset_defs = MagicMock()
+    mock_asset_defs.metadata_by_key.get.return_value = (
+        {"glob_pattern": glob_pattern} if glob_pattern is not None else {}
+    )
+    context.repository_def.assets_defs_by_key = {_ASSET_KEY: mock_asset_defs}
+    return context  # type: ignore[no-any-return]
+
+
+def test_is_asset_running_found() -> None:
+    assert is_asset_running([_make_run(DagsterRunStatus.STARTED)], _ASSET_KEY) is True
+
+
+def test_is_asset_running_ignores_other_assets_and_unselected_runs() -> None:
+    other = AssetKey(["bronze", "other"])
+    assert (
+        is_asset_running([_make_run(DagsterRunStatus.STARTED, other)], _ASSET_KEY)
+        is False
+    )
+    assert (
+        is_asset_running([_make_run(DagsterRunStatus.STARTED, None)], _ASSET_KEY)
+        is False
+    )
+
+
+def test_has_asset_failed_uses_most_recent_matching_completed_run() -> None:
+    assert has_asset_failed([_make_run(DagsterRunStatus.FAILURE)], _ASSET_KEY) is True
+    assert has_asset_failed([_make_run(DagsterRunStatus.SUCCESS)], _ASSET_KEY) is False
+
+
+def test_has_asset_failed_ignores_other_assets_and_unselected_runs() -> None:
+    other = AssetKey(["bronze", "other"])
+    assert (
+        has_asset_failed([_make_run(DagsterRunStatus.FAILURE, other)], _ASSET_KEY)
+        is False
+    )
+    assert (
+        has_asset_failed([_make_run(DagsterRunStatus.FAILURE, None)], _ASSET_KEY)
+        is False
+    )
+
+
+def test_get_asset_glob_pattern_reads_asset_metadata() -> None:
+    context = _build_context(glob_pattern="*.ZIP")
+
+    assert (
+        get_asset_glob_pattern(
+            context,
+            sensor_name="test_sensor",
+            asset_key=_ASSET_KEY,
+        )
+        == "*.ZIP"
+    )
+
+
+def test_get_asset_glob_pattern_requires_metadata() -> None:
+    context = _build_context(glob_pattern=None)
+
+    with pytest.raises(AssertionError, match="missing 'glob_pattern' metadata"):
+        get_asset_glob_pattern(
+            context,
+            sensor_name="test_sensor",
+            asset_key=_ASSET_KEY,
+        )
+
+
+def test_select_s3_pending_object_keys_matches_glob_and_byte_cap() -> None:
+    object_head_mapping: dict[str, S3ObjectHead] = {
+        "bronze/vicgas/a.zip": {"Size": 100},
+        "bronze/vicgas/b.zip": {"Size": 100},
+        "bronze/vicgas/c.txt": {"Size": 1},
+    }
+
+    assert select_s3_pending_object_keys(
+        s3_source_prefix="bronze/vicgas",
+        s3_file_glob="*.zip",
+        object_head_mapping=object_head_mapping,
+        bytes_cap=150,
+        files_cap=None,
+    ) == ["bronze/vicgas/a.zip"]
+
+
+def test_select_s3_pending_object_keys_applies_file_cap() -> None:
+    object_head_mapping: dict[str, S3ObjectHead] = {
+        "bronze/vicgas/a.zip": {"Size": 100},
+        "bronze/vicgas/b.zip": {"Size": 100},
+        "bronze/vicgas/c.zip": {"Size": 100},
+    }
+
+    assert select_s3_pending_object_keys(
+        s3_source_prefix="bronze/vicgas",
+        s3_file_glob="*.zip",
+        object_head_mapping=object_head_mapping,
+        bytes_cap=1_000,
+        files_cap=2,
+    ) == ["bronze/vicgas/a.zip", "bronze/vicgas/b.zip"]
+
+
+def test_build_s3_keys_run_config_targets_asset_config() -> None:
+    run_config = build_s3_keys_run_config(
+        asset_key=_ASSET_KEY,
+        s3_keys=[_ZIP_KEY],
+    )
+
+    assert run_config == {
+        "ops": {
+            _ASSET_KEY.to_python_identifier(): {
+                "config": {
+                    "s3_keys": [_ZIP_KEY],
+                },
+            },
+        },
+    }
+
+
+def test_build_s3_pending_objects_run_request_suppresses_empty_selection() -> None:
+    assert (
+        build_s3_pending_objects_run_request(asset_key=_ASSET_KEY, s3_keys=[]) is None
+    )
+
+
+def test_build_s3_pending_objects_run_request_targets_asset_selection() -> None:
+    run_request = build_s3_pending_objects_run_request(
+        asset_key=_ASSET_KEY,
+        s3_keys=[_ZIP_KEY],
+    )
+
+    assert isinstance(run_request, RunRequest)
+    assert run_request.asset_selection == [_ASSET_KEY]
+    assert run_request.run_config["ops"][_ASSET_KEY.to_python_identifier()]["config"][
+        "s3_keys"
+    ] == [_ZIP_KEY]
+
+
+def test_plan_s3_pending_objects_run_request_gates_active_asset_runs() -> None:
+    context = _build_context()
+
+    with patch(
+        "aemo_etl.factories.s3_pending_objects.get_s3_object_keys_from_prefix_and_name_glob"
+    ) as match_keys:
+        run_request = plan_s3_pending_objects_run_request(
+            context,
+            sensor_name="test_sensor",
+            asset_key=_ASSET_KEY,
+            active_runs=[_make_run(DagsterRunStatus.STARTED)],
+            completed_runs=[],
+            s3_source_prefix="bronze/vicgas",
+            object_head_mapping={_ZIP_KEY: {"Size": 100}},
+            bytes_cap=500,
+            files_cap=None,
+        )
+
+    assert run_request is None
+    match_keys.assert_not_called()
+
+
+def test_plan_s3_pending_objects_run_request_gates_failed_asset_runs() -> None:
+    context = _build_context()
+
+    run_request = plan_s3_pending_objects_run_request(
+        context,
+        sensor_name="test_sensor",
+        asset_key=_ASSET_KEY,
+        active_runs=[],
+        completed_runs=[_make_run(DagsterRunStatus.FAILURE)],
+        s3_source_prefix="bronze/vicgas",
+        object_head_mapping={_ZIP_KEY: {"Size": 100}},
+        bytes_cap=500,
+        files_cap=None,
+    )
+
+    assert run_request is None
+
+
+def test_plan_s3_pending_objects_run_request_suppresses_cap_selected_empty_keys() -> (
+    None
+):
+    context = _build_context()
+
+    run_request = plan_s3_pending_objects_run_request(
+        context,
+        sensor_name="test_sensor",
+        asset_key=_ASSET_KEY,
+        active_runs=[],
+        completed_runs=[],
+        s3_source_prefix="bronze/vicgas",
+        object_head_mapping={_ZIP_KEY: {"Size": 100}},
+        bytes_cap=0,
+        files_cap=None,
+    )
+
+    assert run_request is None
+
+
+def test_plan_s3_pending_objects_run_request_builds_request_for_pending_keys() -> None:
+    context = _build_context()
+
+    run_request = plan_s3_pending_objects_run_request(
+        context,
+        sensor_name="test_sensor",
+        asset_key=_ASSET_KEY,
+        active_runs=[],
+        completed_runs=[],
+        s3_source_prefix="bronze/vicgas",
+        object_head_mapping={_ZIP_KEY: {"Size": 100}},
+        bytes_cap=500,
+        files_cap=None,
+    )
+
+    assert isinstance(run_request, RunRequest)
+    assert run_request.asset_selection == [_ASSET_KEY]
+    assert run_request.run_config["ops"][_ASSET_KEY.to_python_identifier()]["config"][
+        "s3_keys"
+    ] == [_ZIP_KEY]


### PR DESCRIPTION
Closes #25

## Summary

- Added `aemo_etl.factories.s3_pending_objects` for shared S3 pending-object matching, cap selection, empty-selection suppression, run config construction, and asset-run gating helpers.
- Routed `unzipper_sensor` through the shared planner while preserving asset-targeted `RunRequest` behavior.
- Added direct Unit test coverage for the shared planner and kept unzipper sensor behavior covered through Component tests.
- Updated maintained `aemo-etl` doc sync metadata for the new shared Module and unzipper sensor source.

## QA

- `make unit-test` from `backend-services/dagster-user/aemo-etl` - 66 passed
- `make component-test` from `backend-services/dagster-user/aemo-etl` - 230 passed
- `make integration-test` from `backend-services/dagster-user/aemo-etl` - 120 passed
- `make run-prek` from `backend-services/dagster-user/aemo-etl` - passed
- Commit hooks - passed

This PR was opened as a draft after manually finishing a Ralph run that was interrupted due to a nested Codex CLI runner issue.