### PR TITLE
Fix Ralph GitHub and Codex CLI compatibility

### DIFF
--- a/scripts/ralph.py
+++ b/scripts/ralph.py
@@ -158,7 +158,7 @@ class Issue:
             created_at=parse_github_datetime(str(payload.get("createdAt") or "")),
             updated_at=parse_github_datetime(str(payload.get("updatedAt") or "")),
             url=str(payload.get("url") or ""),
-            comments=int(payload.get("comments") or 0),
+            comments=parse_comment_count(payload.get("comments")),
             author=extract_login(payload.get("author")),
         )
 
@@ -211,6 +211,14 @@ def extract_login(value: Any) -> str | None:
     if isinstance(value, dict) and "login" in value:
         return str(value["login"])
     return None
+
+
+def parse_comment_count(value: Any) -> int:
+    if isinstance(value, list):
+        return len(value)
+    if value is None:
+        return 0
+    return int(value)
 
 
 def parse_repo_slug(remote_url: str) -> str:
@@ -344,6 +352,20 @@ def parse_git_status_paths(status_output: str) -> list[str]:
 def looks_like_environment_failure(error: CommandFailure) -> bool:
     output = f"{error.stdout}\n{error.stderr}".lower()
     return any(pattern in output for pattern in ENVIRONMENT_FAILURE_PATTERNS)
+
+
+def codex_exec_command(cwd: Path) -> list[str]:
+    return [
+        "codex",
+        "exec",
+        "--cd",
+        str(cwd),
+        "--sandbox",
+        "workspace-write",
+        "--full-auto",
+        "--json",
+        "-",
+    ]
 
 
 class CommandRunner:
@@ -885,18 +907,7 @@ class RalphLoop:
         if not self.runner.dry_run:
             log_path.with_suffix(".prompt.md").write_text(prompt, encoding="utf-8")
         self.runner.run(
-            [
-                "codex",
-                "exec",
-                "--cd",
-                str(cwd),
-                "--sandbox",
-                "workspace-write",
-                "--ask-for-approval",
-                "never",
-                "--json",
-                "-",
-            ],
+            codex_exec_command(cwd),
             cwd=cwd,
             input_text=prompt,
             log_path=log_path,

--- a/tests/test_ralph.py
+++ b/tests/test_ralph.py
@@ -42,6 +42,23 @@ class RalphHelperTests(unittest.TestCase):
             with self.subTest(remote=remote):
                 self.assertEqual(ralph.parse_repo_slug(remote), expected)
 
+    def test_issue_from_gh_counts_comment_lists_from_issue_list_payload(self) -> None:
+        issue = ralph.Issue.from_gh(
+            {
+                "number": 42,
+                "title": "Implement thing",
+                "body": "",
+                "labels": [{"name": "ready-for-agent"}],
+                "createdAt": "2026-04-30T00:00:00Z",
+                "updatedAt": "2026-04-30T00:00:00Z",
+                "url": "https://github.com/example/repo/issues/42",
+                "comments": [{"id": "one"}, {"id": "two"}],
+                "author": {"login": "reporter"},
+            }
+        )
+
+        self.assertEqual(issue.comments, 2)
+
     def test_slugify_limits_and_normalizes_titles(self) -> None:
         self.assertEqual(
             ralph.slugify("Introduce shared S3 pending-object planning!"),
@@ -144,6 +161,22 @@ Build it.
             None,
         )
         self.assertTrue(ralph.looks_like_environment_failure(error))
+
+    def test_codex_exec_command_uses_supported_unattended_flags(self) -> None:
+        self.assertEqual(
+            ralph.codex_exec_command(Path("/repo")),
+            [
+                "codex",
+                "exec",
+                "--cd",
+                "/repo",
+                "--sandbox",
+                "workspace-write",
+                "--full-auto",
+                "--json",
+                "-",
+            ],
+        )
 
     def test_default_worktree_container_matches_sibling_worktree_layout(self) -> None:
         current = Path("/work/repo__worktrees/refactor")


### PR DESCRIPTION
## Summary

- Accept both list-shaped and count-shaped `gh issue` comment payloads when parsing issue JSON.
- Update Ralph's nested Codex invocation to use the current `codex exec --full-auto` flag instead of the removed `--ask-for-approval never` option.
- Add focused Ralph unit tests for both compatibility cases.

## QA

- `python3 -m unittest discover -s tests` - 14 passed
- `python3 scripts/ralph.py --drain --dry-run` - confirmed no unblocked ready or triage-actionable issues remain after PR #27
- `prek run -a` - passed

This PR captures the Ralph script fixes discovered while draining the issue queue.