### PR TITLE
Implement #30: Pilot Google docstring Ruff ratchet in the marimo Subproject

### DIFF
--- a/backend-services/marimo/pyproject.toml
+++ b/backend-services/marimo/pyproject.toml
@@ -36,10 +36,12 @@ dev = [
 [tool.ruff]
 line-length = 88
 format.docstring-code-format = true
-lint.select = [ "ANN", "E", "F" ]
+lint.select = [ "ANN", "D", "E", "F" ]
 lint.per-file-ignores."__init__.py" = [ "I" ]
-lint.per-file-ignores."notebooks/*.py" = [ "ANN" ]
+lint.per-file-ignores."notebooks/*.py" = [ "ANN", "D" ]
+lint.per-file-ignores."tests/**" = [ "D" ]
 lint.pycodestyle.max-line-length = 120
+lint.pydocstyle.convention = "google"
 
 [tool.pytest]
 ini_options.testpaths = [ "tests" ]

--- a/backend-services/marimo/src/marimoserver/__init__.py
+++ b/backend-services/marimo/src/marimoserver/__init__.py
@@ -1,0 +1,1 @@
+"""FastAPI service for hosting marimo notebooks."""

--- a/backend-services/marimo/src/marimoserver/main.py
+++ b/backend-services/marimo/src/marimoserver/main.py
@@ -1,5 +1,4 @@
-"""
-Marimo notebook server — FastAPI wrapper.
+"""FastAPI wrapper for the marimo notebook server.
 
 Serves marimo notebooks from the ``notebooks/`` directory using marimo's
 built-in ASGI integration (``marimo.create_asgi_app``).  A ``/health``
@@ -52,9 +51,11 @@ class MimeTypeFixMiddleware:  # pragma: no cover
     }
 
     def __init__(self, app: ASGIApp) -> None:
+        """Store the wrapped ASGI app."""
         self.app = app
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        """Patch font response MIME types before sending HTTP responses."""
         if scope["type"] != "http":
             await self.app(scope, receive, send)
             return


### PR DESCRIPTION
Closes #30

## Summary

Implements `Pilot Google docstring Ruff ratchet in the marimo Subproject` through the Ralph agent issue loop.

## Changed files

- `backend-services/marimo/pyproject.toml`
- `backend-services/marimo/src/marimoserver/__init__.py`
- `backend-services/marimo/src/marimoserver/main.py`

## QA

- `prek run -a` from `/home/cmamon/GitHub/energy-market-delta-lake__worktrees/agent-issue-30-pilot-google-docstring-ruff-ratchet-in-the-marimo-subpro`

Run logs: `/home/cmamon/GitHub/energy-market-delta-lake__worktrees/build-add-pylint/.ralph/runs/issue-30-20260430T114340Z`

This PR was opened as a draft by the Ralph loop for human review.
